### PR TITLE
Update PluginGeneratorWidget.ui

### DIFF
--- a/plugindevtools/PluginDevTools/PluginGeneratorWidget.ui
+++ b/plugindevtools/PluginDevTools/PluginGeneratorWidget.ui
@@ -79,7 +79,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="projectPathHeaderLabel">
         <property name="text">
          <string>Project Path: (project path will symlink to your pykrita folder)</string>
         </property>


### PR DESCRIPTION
Solves error when toggling `Use Symlink` in PluginGenerator.py

`pykrita\PluginDevTools\PluginGenerator.py", line 205, in toggleSymlink
    self.centralWidget.projectPathHeaderLabel.setText('Project Path:')
AttributeError: 'QWidget' object has no attribute 'projectPathHeaderLabel' `