### PR TITLE
Better console contrast for print()

### DIFF
--- a/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
+++ b/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
@@ -743,7 +743,12 @@ Would you like to download the API details(less than 200kb of data) automaticall
 
 
             item = QStandardItem( f.getvalue() )
-            item.setForeground(QBrush(QColor('#1eb131')))
+            if QtWidgets.qApp.palette().window().color().value() > QtWidgets.qApp.palette().windowText().color().value(): 
+                # color for light themes
+                item.setForeground(QBrush(QColor('#094813')))
+            else: 
+                # color for dark themes
+                item.setForeground(QBrush(QColor('#1eb131')))
             rootItem.appendRow( item )
 
             self.historyTreeView.expand(self.proxyModel.mapFromSource(rootItem.index()));

--- a/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
+++ b/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
@@ -743,7 +743,7 @@ Would you like to download the API details(less than 200kb of data) automaticall
 
 
             item = QStandardItem( f.getvalue() )
-            item.setForeground(QBrush(QColor('#000099')))
+            item.setForeground(QBrush(QColor('#1eb131')))
             rootItem.appendRow( item )
 
             self.historyTreeView.expand(self.proxyModel.mapFromSource(rootItem.index()));

--- a/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
+++ b/plugindevtools/PluginDevTools/PluginDevToolsWidget.py
@@ -748,7 +748,7 @@ Would you like to download the API details(less than 200kb of data) automaticall
                 item.setForeground(QBrush(QColor('#094813')))
             else: 
                 # color for dark themes
-                item.setForeground(QBrush(QColor('#1eb131')))
+                item.setForeground(QBrush(QColor('#25DA3D')))
             rootItem.appendRow( item )
 
             self.historyTreeView.expand(self.proxyModel.mapFromSource(rootItem.index()));


### PR DESCRIPTION
The prints in the console tab were very hard to see in dark themes:

![imagen](https://github.com/KnowZero/Krita-PythonPluginDeveloperTools/assets/52723367/f0e16099-0a5d-4928-9208-f9f588da8ac2)

(I've choosen a green because it stills remain "neutral" as blue (or at least is not a warning/error color)).